### PR TITLE
Switch the parameter order in {prop,nth}{Satisfies,Equals}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | `atEquals`    | `nthEquals`    |
 | `atSatisfies` | `nthSatisfies` |
 
+- Changed the parameter order of `propEquals`, `propSatisfies`, `nthEquals` and `nthSatisfies`. Now the key or index is
+  the first parameter while the value or predicate is the second
+  parameter. ([#239](https://github.com/sluukkonen/iiris/pull/239))
+
 ## [0.0.1] - 2021-04-06
 
 - Initial public release

--- a/README.md
+++ b/README.md
@@ -600,7 +600,7 @@ I.nthOr(999, 0, [undefined])
 #### nthSatisfies
 
 ```typescript
-<T>(predicate: (value: T) => boolean) => (index: number) => (array: T[]) => boolean
+(index: number) => <T>(predicate: (value: T) => boolean) => (array: T[]) => boolean
 ```
 
 Check if the nth element of `array` satisfies the `predicate`.
@@ -608,7 +608,7 @@ Check if the nth element of `array` satisfies the `predicate`.
 **Example:**
 
 ```typescript
-I.nthSatisfies(I.gt(0), 0, [1, 2, 3])
+I.nthSatisfies(0, I.gt(0), [1, 2, 3])
 // => true
 ```
 
@@ -2487,7 +2487,7 @@ I.propOr(999, 'a', { a: undefined })
 #### propSatisfies
 
 ```typescript
-<V>(predicate: (value: V) => boolean) => <K extends string>(key: K) => <T extends HasKey<K, V>>(object: T) => boolean
+<K extends string>(key: K) => <V>(predicate: (value: V) => boolean) => <T extends HasKey<K, V>>(object: T) => boolean
 ```
 
 Check if property `key` of `object` satisfies the `predicate`.
@@ -2500,7 +2500,7 @@ const users = [
   { name: 'Bob' },
 ]
 
-I.some(I.propSatisfies(I.test(/^A/), 'name'), users)
+I.some(I.propSatisfies('name', I.test(/^A/)), users)
 // => true
 ```
 

--- a/__tests__/nthSatisfies.test.js
+++ b/__tests__/nthSatisfies.test.js
@@ -4,7 +4,7 @@ import { equals } from '../src/equals'
 it('checks if an element of an array satisfies a predicate', () => {
   const arr = [1]
 
-  expect(nthSatisfies(equals(1), 0, arr)).toBe(true)
-  expect(nthSatisfies(equals(2), 0, arr)).toBe(false)
-  expect(nthSatisfies(equals(1), 1, arr)).toBe(false)
+  expect(nthSatisfies(0, equals(1), arr)).toBe(true)
+  expect(nthSatisfies(0, equals(2), arr)).toBe(false)
+  expect(nthSatisfies(1, equals(1), arr)).toBe(false)
 })

--- a/__tests__/propSatisfies.test.js
+++ b/__tests__/propSatisfies.test.js
@@ -4,7 +4,7 @@ import { equals } from '../src/equals'
 it('checks if a property satisfies a predicate', () => {
   const obj = { a: 1 }
 
-  expect(propSatisfies(equals(1), 'a', obj)).toBe(true)
-  expect(propSatisfies(equals(2), 'a', obj)).toBe(false)
-  expect(propSatisfies(equals(undefined), 'b', obj)).toBe(false)
+  expect(propSatisfies('a', equals(1), obj)).toBe(true)
+  expect(propSatisfies('a', equals(2), obj)).toBe(false)
+  expect(propSatisfies('b', equals(undefined), obj)).toBe(false)
 })

--- a/index.d.ts
+++ b/index.d.ts
@@ -2406,25 +2406,25 @@ export function nthOr<T>(defaultValue: T, index: number, array: readonly T[]): T
  * @example
  *
  * ```typescript
- * I.nthSatisfies(I.gt(0), 0, [1, 2, 3])
+ * I.nthSatisfies(0, I.gt(0), [1, 2, 3])
  * // => true
  * ```
  *
  * @see nthSatisfies
  */
-export function nthSatisfies<T>(
-  predicate: (value: T) => boolean
+export function nthSatisfies(
+  index: number
 ): {
-  (index: number): (array: readonly T[]) => boolean
-  (index: number, array: readonly T[]): boolean
+  <T>(predicate: (value: T) => boolean): (array: readonly T[]) => boolean
+  <T>(predicate: (value: T) => boolean, array: readonly T[]): boolean
 }
 export function nthSatisfies<T>(
-  predicate: (value: T) => boolean,
-  index: number
+  index: number,
+  predicate: (value: T) => boolean
 ): (array: readonly T[]) => boolean
 export function nthSatisfies<T>(
-  predicate: (value: T) => boolean,
   index: number,
+  predicate: (value: T) => boolean,
   array: readonly T[]
 ): boolean
 
@@ -2712,25 +2712,30 @@ export function propOr<V extends T[K], K extends keyof T & string, T>(
  *   { name: 'Bob' },
  * ]
  *
- * I.some(I.propSatisfies(I.test(/^A/), 'name'), users)
+ * I.some(I.propSatisfies('name', I.test(/^A/)), users)
  * // => true
  * ```
  *
  * @see propEquals
  */
-export function propSatisfies<V>(
-  predicate: (value: V) => boolean
-): {
-  <K extends string>(key: K): <T extends HasKey<K, V>>(object: T) => boolean
-  <K extends string, T extends HasKey<K, V>>(key: K, object: T): boolean
-}
-export function propSatisfies<V, K extends string>(
-  predicate: (value: V) => boolean,
+export function propSatisfies<K extends string>(
   key: K
+): {
+  <V>(predicate: (value: V) => boolean): <T extends HasKey<K, V>>(
+    object: T
+  ) => boolean
+  <T extends HasKey<K>>(
+    predicate: (value: Defined<T[K]>) => boolean,
+    object: T
+  ): boolean
+}
+export function propSatisfies<K extends string, V>(
+  key: K,
+  predicate: (value: V) => boolean
 ): <T extends HasKey<K, V>>(object: T) => boolean
 export function propSatisfies<K extends keyof T & string, T extends object>(
-  predicate: (value: Defined<T[K]>) => boolean,
   key: K,
+  predicate: (value: Defined<T[K]>) => boolean,
   object: T
 ): boolean
 

--- a/src/internal/nthSatiesfiesU.js
+++ b/src/internal/nthSatiesfiesU.js
@@ -1,7 +1,7 @@
 import { getIndex } from './getIndex'
 import { hasIndex } from './hasIndex'
 
-export const nthSatisfiesU = (fn, index, array) => {
+export const nthSatisfiesU = (index, fn, array) => {
   index = getIndex(index, array)
   return hasIndex(index, array) && fn(array[index])
 }

--- a/src/internal/propSatisfiesU.js
+++ b/src/internal/propSatisfiesU.js
@@ -1,4 +1,4 @@
 import { hasOwn } from './hasOwn'
 
-export const propSatisfiesU = (fn, key, object) =>
+export const propSatisfiesU = (key, fn, object) =>
   hasOwn(object, key) && fn(object[key])

--- a/test-d/propSatisfies.test-d.ts
+++ b/test-d/propSatisfies.test-d.ts
@@ -1,17 +1,23 @@
-import { expectType } from 'tsd'
+import { expectError, expectType } from 'tsd'
 import * as I from '..'
 import { user } from './index.test-d'
 
 const startsWithA = I.test(/^a/)
 
 // Normal value
-expectType<boolean>(I.propSatisfies(startsWithA, 'name', user))
-expectType<boolean>(I.propSatisfies(startsWithA, 'name')(user))
-expectType<boolean>(I.propSatisfies(startsWithA)('name', user))
-expectType<boolean>(I.propSatisfies(startsWithA)('name')(user))
+expectType<boolean>(I.propSatisfies('name', startsWithA, user))
+expectType<boolean>(I.propSatisfies('name', startsWithA)(user))
+expectType<boolean>(I.propSatisfies('name')(startsWithA, user))
+expectType<boolean>(I.propSatisfies('name')(startsWithA)(user))
 
 // Nullable value
-expectType<boolean>(I.propSatisfies(I.gt(0), 'age', user))
-expectType<boolean>(I.propSatisfies(I.gt(0), 'age')(user))
-expectType<boolean>(I.propSatisfies(I.gt(0))('age', user))
-expectType<boolean>(I.propSatisfies(I.gt(0))('age')(user))
+expectType<boolean>(I.propSatisfies('age', I.gt(0), user))
+expectType<boolean>(I.propSatisfies('age', I.gt(0))(user))
+expectType<boolean>(I.propSatisfies('age')(I.gt(0), user))
+expectType<boolean>(I.propSatisfies('age')(I.gt(0))(user))
+
+// Wrong type
+expectError(I.propSatisfies('age', startsWithA, user))
+expectError(I.propSatisfies('age', startsWithA)(user))
+expectError(I.propSatisfies('age')(startsWithA, user))
+expectError(I.propSatisfies('age')(startsWithA)(user))


### PR DESCRIPTION
While an argument could be made for either order, this feels more natural to me.